### PR TITLE
NS-99: Remove deprecated SurrealDB references from nlp-engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,7 @@ The engine supports automatic device detection (CPU/CUDA/Metal) and lazy model l
 
 ### Vector Database Integration
 
-**Current**: SurrealDB integration for basic vector operations
-**Target**: LanceDB for optimized vector storage and retrieval
+**Current**: LanceDB integration for optimized vector storage and retrieval
 
 The engine is designed for efficient vector operations:
 - Embeddings stored in optimized columnar format
@@ -196,7 +195,7 @@ See [Multimodal Evaluation Strategy](docs/multimodal-evaluation-strategy.md) for
 
 This is part of the NodeSpace distributed system architecture:
 1. `nodespace-core-types` - Shared interfaces and data structures
-2. `nodespace-data-store` - SurrealDB entity storage + future LanceDB integration
+2. `nodespace-data-store` - LanceDB vector storage
 3. **`nodespace-nlp-engine`** - Multimodal AI/ML processing layer (this repository)
 4. `nodespace-workflow-engine` - Automation and events
 5. `nodespace-core-logic` - Business logic orchestration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nodespace-nlp-engine"
 version = "0.1.0"
 edition = "2021"
-description = "AI/ML processing and SurrealDB integration for NodeSpace"
+description = "AI/ML processing and LanceDB integration for NodeSpace"
 license = "MIT"
 repository = "https://github.com/malibio/nodespace-nlp-engine"
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ let vqa_response = engine.answer_image_question(&image_bytes, "What do you see?"
 Part of the [NodeSpace system architecture](../nodespace-system-design/README.md):
 
 1. `nodespace-core-types` - Shared data structures and interfaces
-2. `nodespace-data-store` - SurrealDB-based entity storage with graph relationships  
+2. `nodespace-data-store` - LanceDB-based vector storage with semantic relationships  
 3. **`nodespace-nlp-engine`** ← **You are here** (Multimodal AI + vector storage)
 4. `nodespace-workflow-engine` - Automation and event processing
 5. `nodespace-core-logic` - Business logic orchestration

--- a/docs/implementation-phases.md
+++ b/docs/implementation-phases.md
@@ -67,7 +67,7 @@ let response = engine.generate_text("Summarize the key points").await?;
 ### 🎯 Phase 2 Objectives
 
 #### Infrastructure Upgrades
-- **LanceDB Integration**: Migrate from SurrealDB to LanceDB for optimized vector operations
+- **LanceDB Integration**: Completed migration to LanceDB for optimized vector operations
 - **Dual Embedding Support**: Extend architecture to handle both text and image embeddings
 - **Image Processing Pipeline**: Add image loading, preprocessing, and metadata extraction
 - **Model Management**: Support for multiple model types (text, image, multimodal)

--- a/examples/text_generation.rs
+++ b/examples/text_generation.rs
@@ -1,4 +1,4 @@
-//! Example demonstrating text generation and SurrealQL generation
+//! Example demonstrating text generation capabilities
 
 use nodespace_nlp_engine::{LocalNLPEngine, NLPEngine};
 


### PR DESCRIPTION
Resolves NS-99

## Summary

Phase 1 cleanup of deprecated SurrealDB references from nodespace-nlp-engine repository after completed migration to LanceDB.

## Changes Made

### Documentation Updates
- **Cargo.toml**: Updated description to reflect LanceDB integration
- **README.md**: Updated architecture overview to show LanceDB-based vector storage
- **CLAUDE.md**: Corrected vector database integration section to reflect completed migration
- **docs/implementation-phases.md**: Updated status to show LanceDB integration as completed

### Code Cleanup
- **examples/text_generation.rs**: Removed SurrealQL reference from comment
- Verified zero remaining SurrealDB/SurrealQL references in codebase

## Testing

- ✅ All tests pass: `cargo test --lib`
- ✅ Clean compilation: `cargo check` 
- ✅ Linting clean: `cargo clippy -- -D warnings`
- ✅ Formatting verified: `cargo fmt --check`
- ✅ Zero remaining SurrealDB references confirmed

## Impact

**Risk**: None - purely documentation cleanup
**Breaking Changes**: None
**Dependencies**: No external dependencies on removed references

The LanceDB migration was already completed in previous work. This PR simply updates documentation and comments to accurately reflect the current implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)